### PR TITLE
Tweak build options

### DIFF
--- a/ficl.h
+++ b/ficl.h
@@ -109,7 +109,6 @@ extern "C" {
 #endif
 
 #include "sysdep.h"
-#include <stdio.h>
 
 /*
 ** Forward declarations... read on.
@@ -1114,7 +1113,9 @@ void       ficlCompilePrefix(FICL_SYSTEM *pSys);
 void       ficlCompileSearch(FICL_SYSTEM *pSys);
 void       ficlCompileSoftCore(FICL_SYSTEM *pSys);
 void       ficlCompileTools(FICL_SYSTEM *pSys);
+#if FICL_WANT_FILE
 void       ficlCompileFile(FICL_SYSTEM *pSys);
+#endif
 #if FICL_WANT_FLOAT
 void       ficlCompileFloat(FICL_SYSTEM *pSys);
 bool       ficlParseFloatNumber( FICL_VM *pVM, STRINGINFO si ); /* float.c */
@@ -1170,6 +1171,7 @@ WORDKIND   ficlWordClassify(FICL_WORD *pFW);
 /*
 ** Used with File-Access wordset.
 */
+#if FICL_WANT_FILE
 #define FICL_FAM_READ   1
 #define FICL_FAM_WRITE  2
 #define FICL_FAM_APPEND 4
@@ -1177,12 +1179,14 @@ WORDKIND   ficlWordClassify(FICL_WORD *pFW);
 
 #define FICL_FAM_OPEN_MODE(fam) ((fam) & (FICL_FAM_READ | FICL_FAM_WRITE | FICL_FAM_APPEND))
 
+#include <stdio.h>
 
 typedef struct ficlFILE
 {
     FILE *f;
     char filename[256];
 } ficlFILE;
+#endif
 
 #ifdef __cplusplus
 }

--- a/fileaccess.c
+++ b/fileaccess.c
@@ -1,3 +1,7 @@
+#include "ficl.h"
+
+#if FICL_WANT_FILE
+
 #include <errno.h>
 #include <stdlib.h>
 #if defined(_WIN32)
@@ -11,9 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
-#include "ficl.h"
 
-#if FICL_WANT_FILE
 /*
 **
 ** fileaccess.c
@@ -401,10 +403,6 @@ static void ficlResizeFile(FICL_VM *pVM) /* ( ud fileid -- ior ) */
 
 #endif /* FICL_HAVE_FTRUNCATE */
 
-#endif /* FICL_WANT_FILE */
-
-
-#if FICL_WANT_FILE
 void ficlCompileFile(FICL_SYSTEM *pSys)
 {
     FICL_DICT *dp = pSys->dp;
@@ -434,6 +432,5 @@ void ficlCompileFile(FICL_SYSTEM *pSys)
     ficlSetEnv(pSys, "file-ext", FICL_TRUE);
 #endif /* FICL_HAVE_FTRUNCATE */
 }
-#else
-#define ficlCompileFile(pSys) ((void)(pSys))
+
 #endif /* FICL_WANT_FILE */

--- a/float.c
+++ b/float.c
@@ -42,14 +42,15 @@
 ** SUCH DAMAGE.
 */
 
+#include "ficl.h"
+
+#if FICL_WANT_FLOAT
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
 #include <float.h>
-#include "ficl.h"
-
-#if FICL_WANT_FLOAT
 
 /*******************************************************************
 ** Create a floating point constant.

--- a/sysdep.h
+++ b/sysdep.h
@@ -186,6 +186,7 @@ typedef jmp_buf FICL_JMP_BUF;
 #define FICL_WANT_FILE       0
 #define FICL_WANT_FLOAT      0
 #define FICL_WANT_USER       0
+#define FICL_WANT_RANDOM     0
 #define FICL_WANT_LOCALS     0
 #define FICL_WANT_OOP        0
 #define FICL_PLATFORM_EXTEND 0
@@ -222,6 +223,14 @@ typedef jmp_buf FICL_JMP_BUF;
 */
 #if !defined (FICL_WANT_FLOAT)
 #define FICL_WANT_FLOAT 1
+#endif
+
+/*
+** FICL_WANT_RANDOM
+** Includes random and seed-random.
+*/
+#if !defined (FICL_WANT_RANDOM)
+#define FICL_WANT_RANDOM 1
 #endif
 
 

--- a/words.c
+++ b/words.c
@@ -3887,6 +3887,7 @@ WORDKIND ficlWordClassify(FICL_WORD *pFW)
 **                     r a n d o m
 ** FICL-specific PCG32 implementation
 **************************************************************************/
+#if FICL_WANT_RANDOM
 static uint64_t rndState;
 static uint64_t rndInc;
 static bool rndIsSeeded;
@@ -3930,6 +3931,7 @@ static void ficlSeedRandom(FICL_VM *pVM)
     rndSeed((uint32_t)POPINT());
     rndIsSeeded = true;
 }
+#endif
 
 
 /**************************************************************************
@@ -4254,8 +4256,10 @@ void ficlCompileCore(FICL_SYSTEM *pSys)
     dictAppendOpWord(dp, "(user)",    FICL_OP_USER,   FW_DEFAULT);
     dictAppendWord(  dp, "user",      userVariable,   FW_DEFAULT);
 #endif
+#if FICL_WANT_RANDOM
     dictAppendWord(  dp, "random",    ficlRandom,     FW_DEFAULT);
     dictAppendWord(  dp, "seed-random",ficlSeedRandom,FW_DEFAULT);
+#endif
 
     /*
     ** internal support words


### PR DESCRIPTION
Ensure FICL_WANT_FLOAT=0 and FICL_WANT_FILE=0 also keep out relevant header files, for the benefit of builds without full libc. Introduce FICL_WANT_RANDOM for the same reason. Gratis: sniped a redundant use of isupper().

I suggest you check the build flag combinations you use, in  case I missed some side effect.

Note that some checked-in files use CRLF format. I propose you mass convert them to unix line format. (Not addressed in this PR).

